### PR TITLE
Add Helm chart customization options and improve VPA ownership

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -67,6 +67,29 @@ jobs:
         cache-from: type=gha
         cache-to: type=gha,mode=max
 
+    - name: Set up Helm
+      uses: azure/setup-helm@v4
+      with:
+        version: v3.14.0
+
+    - name: Package and push Helm chart
+      run: |
+        # Extract version from tag (remove 'v' prefix)
+        VERSION=${GITHUB_REF#refs/tags/v}
+        
+        # Update Chart.yaml with release version
+        sed -i "s/^version:.*/version: ${VERSION}/" charts/vpa-operator/Chart.yaml
+        sed -i "s/^appVersion:.*/appVersion: \"${VERSION}\"/" charts/vpa-operator/Chart.yaml
+        
+        # Update default image tag in values.yaml
+        sed -i "s/^  tag:.*/  tag: \"${VERSION}\"/" charts/vpa-operator/values.yaml
+        
+        # Package the chart
+        helm package charts/vpa-operator
+        
+        # Push to GHCR OCI registry
+        helm push vpa-operator-${VERSION}.tgz oci://${{ env.REGISTRY }}/${{ github.repository_owner }}/charts
+
     - name: Generate release notes
       id: release_notes
       run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -64,8 +64,6 @@ jobs:
         push: true
         tags: ${{ steps.meta.outputs.tags }}
         labels: ${{ steps.meta.outputs.labels }}
-        build-args: |
-          TARGETARCH=amd64
         cache-from: type=gha
         cache-to: type=gha,mode=max
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - Status updates now use `Patch` instead of `Update` to avoid race conditions with stale `resourceVersion`
+- **Performance**: Workload iteration now uses pagination (500 items per page) to reduce memory usage
+- **Performance**: Status now stores counts by workload type instead of full workload list (prevents etcd size limits)
+- **Performance**: VPA updates use hash-based change detection to skip unnecessary API calls
 
 ### Fixed
 - VPA owner references now include `Controller: true` and `BlockOwnerDeletion: true` for proper Kubernetes garbage collection

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - VPA owner references now include `Controller: true` and `BlockOwnerDeletion: true` for proper Kubernetes garbage collection
 - Improved Helm chart extensibility with support for `commonLabels`, `commonAnnotations`, `podLabels`, and `podAnnotations`
+- Added missing `statefulSetSelector` and `daemonSetSelector` to `defaultVpaManager` Helm values
 
 ### Added
 - E2E test for validating VPA owner reference configuration

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- Status updates now use `Patch` instead of `Update` to avoid race conditions with stale `resourceVersion`
+
+### Fixed
+- VPA owner references now include `Controller: true` and `BlockOwnerDeletion: true` for proper Kubernetes garbage collection
+- Improved Helm chart extensibility with support for `commonLabels`, `commonAnnotations`, `podLabels`, and `podAnnotations`
+
+### Added
+- E2E test for validating VPA owner reference configuration
+- GitHub Container Registry (GHCR) support in CI/CD workflows
+
 ## [0.1.0] - 2026-01-14
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.0] - 2026-01-15
+
 ### Changed
 - Status updates now use `Patch` instead of `Update` to avoid race conditions with stale `resourceVersion`
 
@@ -17,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - E2E test for validating VPA owner reference configuration
 - GitHub Container Registry (GHCR) support in CI/CD workflows
+- Helm chart publishing to GHCR OCI registry (`oci://ghcr.io/joaomo/charts/vpa-operator`)
 
 ## [0.1.0] - 2026-01-14
 
@@ -39,5 +42,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Dropped all Linux capabilities
 - Security context with `allowPrivilegeEscalation: false`
 
-[Unreleased]: https://github.com/joaomo/k8s_op_vpa/compare/v0.1.0...HEAD
+[Unreleased]: https://github.com/joaomo/k8s_op_vpa/compare/v0.2.0...HEAD
+[0.2.0]: https://github.com/joaomo/k8s_op_vpa/compare/v0.1.0...v0.2.0
 [0.1.0]: https://github.com/joaomo/k8s_op_vpa/releases/tag/v0.1.0

--- a/api/v1/vpamanager_types.go
+++ b/api/v1/vpamanager_types.go
@@ -78,15 +78,27 @@ type DeploymentReference = WorkloadReference
 
 // VpaManagerStatus defines the observed state of VpaManager
 type VpaManagerStatus struct {
-	// ManagedVPAs is the number of VPAs managed by this operator
+	// ManagedVPAs is the total number of VPAs managed by this operator
 	ManagedVPAs int `json:"managedVPAs"`
 
 	// ManagedDeployments is a list of deployments that have VPAs
-	// Deprecated: Use ManagedWorkloads instead
+	// Deprecated: Use ManagedWorkloads instead. Will be removed in v1.
+	// +optional
 	ManagedDeployments []WorkloadReference `json:"managedDeployments,omitempty"`
 
-	// ManagedWorkloads is a list of all workloads (Deployments and StatefulSets) that have VPAs
+	// ManagedWorkloads is a list of all workloads that have VPAs
+	// Deprecated: This field is expensive at scale. Use count fields instead.
+	// +optional
 	ManagedWorkloads []WorkloadReference `json:"managedWorkloads,omitempty"`
+
+	// DeploymentCount is the number of deployments with managed VPAs
+	DeploymentCount int `json:"deploymentCount,omitempty"`
+
+	// StatefulSetCount is the number of statefulsets with managed VPAs
+	StatefulSetCount int `json:"statefulSetCount,omitempty"`
+
+	// DaemonSetCount is the number of daemonsets with managed VPAs
+	DaemonSetCount int `json:"daemonSetCount,omitempty"`
 
 	// LastReconcileTime is the last time the operator reconciled
 	LastReconcileTime *metav1.Time `json:"lastReconcileTime,omitempty"`

--- a/charts/vpa-operator/templates/_helpers.tpl
+++ b/charts/vpa-operator/templates/_helpers.tpl
@@ -38,6 +38,18 @@ helm.sh/chart: {{ include "vpa-operator.chart" . }}
 app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 {{- end }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- with .Values.commonLabels }}
+{{ toYaml . }}
+{{- end }}
+{{- end }}
+
+{{/*
+Common annotations
+*/}}
+{{- define "vpa-operator.annotations" -}}
+{{- with .Values.commonAnnotations }}
+{{ toYaml . }}
+{{- end }}
 {{- end }}
 
 {{/*

--- a/charts/vpa-operator/templates/deployment.yaml
+++ b/charts/vpa-operator/templates/deployment.yaml
@@ -6,6 +6,10 @@ metadata:
   labels:
     {{- include "vpa-operator.labels" . | nindent 4 }}
     control-plane: controller-manager
+  {{- with .Values.commonAnnotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   replicas: {{ .Values.replicaCount }}
   selector:
@@ -17,6 +21,13 @@ spec:
       labels:
         {{- include "vpa-operator.selectorLabels" . | nindent 8 }}
         control-plane: controller-manager
+        {{- with .Values.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
     spec:
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:

--- a/charts/vpa-operator/templates/rbac.yaml
+++ b/charts/vpa-operator/templates/rbac.yaml
@@ -5,6 +5,10 @@ metadata:
   name: {{ include "vpa-operator.fullname" . }}-manager
   labels:
     {{- include "vpa-operator.labels" . | nindent 4 }}
+  {{- with .Values.commonAnnotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 rules:
 - apiGroups:
   - operators.joaomo.io
@@ -69,6 +73,10 @@ metadata:
   name: {{ include "vpa-operator.fullname" . }}-manager
   labels:
     {{- include "vpa-operator.labels" . | nindent 4 }}
+  {{- with .Values.commonAnnotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -85,6 +93,10 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "vpa-operator.labels" . | nindent 4 }}
+  {{- with .Values.commonAnnotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 rules:
 - apiGroups:
   - ""
@@ -125,6 +137,10 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "vpa-operator.labels" . | nindent 4 }}
+  {{- with .Values.commonAnnotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role

--- a/charts/vpa-operator/templates/serviceaccount.yaml
+++ b/charts/vpa-operator/templates/serviceaccount.yaml
@@ -6,8 +6,13 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "vpa-operator.labels" . | nindent 4 }}
-  {{- with .Values.serviceAccount.annotations }}
+  {{- if or .Values.commonAnnotations .Values.serviceAccount.annotations }}
   annotations:
+    {{- with .Values.commonAnnotations }}
     {{- toYaml . | nindent 4 }}
+    {{- end }}
+    {{- with .Values.serviceAccount.annotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
   {{- end }}
 {{- end }}

--- a/charts/vpa-operator/values.yaml
+++ b/charts/vpa-operator/values.yaml
@@ -94,3 +94,5 @@ defaultVpaManager:
     updateMode: "Off"
     namespaceSelector: {}
     deploymentSelector: {}
+    statefulSetSelector: {}
+    daemonSetSelector: {}

--- a/charts/vpa-operator/values.yaml
+++ b/charts/vpa-operator/values.yaml
@@ -11,6 +11,18 @@ imagePullSecrets: []
 nameOverride: ""
 fullnameOverride: ""
 
+# Common labels to add to all resources
+commonLabels: {}
+
+# Common annotations to add to all resources
+commonAnnotations: {}
+
+# Additional labels for pods
+podLabels: {}
+
+# Additional annotations for pods
+podAnnotations: {}
+
 serviceAccount:
   create: true
   annotations: {}

--- a/examples/argocd/values-argocd.yaml
+++ b/examples/argocd/values-argocd.yaml
@@ -1,0 +1,19 @@
+# ArgoCD deployment values for vpa-operator
+# Enables automatic VpaManager creation in recommendation mode
+
+image:
+  repository: ghcr.io/joaomo/k8s_op_vpa
+  tag: "0.1.0"
+
+# Enable the default VpaManager resource
+defaultVpaManager:
+  enabled: true
+  name: default
+  spec:
+    enabled: true
+    # "Off" mode = recommendation only (no auto-updates)
+    updateMode: "Off"
+    # Apply to all namespaces (customize as needed)
+    namespaceSelector: {}
+    # Apply to all deployments (customize as needed)
+    deploymentSelector: {}

--- a/examples/argocd/vpa-operator-app.yaml
+++ b/examples/argocd/vpa-operator-app.yaml
@@ -1,0 +1,24 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: vpa-operator
+  namespace: argocd
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/joaomo/k8s_op_vpa.git
+    targetRevision: v0.1.0
+    path: charts/vpa-operator
+    helm:
+      valueFiles:
+        - values-argocd.yaml
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: vpa-operator-system
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true
+      - ServerSideApply=true

--- a/examples/argocd/vpa-operator-app.yaml
+++ b/examples/argocd/vpa-operator-app.yaml
@@ -6,9 +6,10 @@ metadata:
 spec:
   project: default
   source:
-    repoURL: https://github.com/joaomo/k8s_op_vpa.git
-    targetRevision: v0.1.0
-    path: charts/vpa-operator
+    # OCI Helm chart from GitHub Container Registry
+    repoURL: ghcr.io/joaomo/charts
+    chart: vpa-operator
+    targetRevision: 0.2.0
     helm:
       valueFiles:
         - values-argocd.yaml

--- a/hack/validate-operator.sh
+++ b/hack/validate-operator.sh
@@ -329,6 +329,61 @@ test_vpa_configuration() {
 }
 
 #######################################
+# Test: VPA owner reference
+#######################################
+test_vpa_owner_reference() {
+    log_step "Test: VPA has correct owner reference for garbage collection"
+
+    # Check owner reference exists and points to deployment
+    local owner_kind
+    owner_kind=$(kubectl get vpa test-app-vpa -n "${TEST_NAMESPACE}" -o jsonpath='{.metadata.ownerReferences[0].kind}' 2>/dev/null)
+
+    if [[ "${owner_kind}" == "Deployment" ]]; then
+        log_success "VPA owner reference kind is 'Deployment'"
+        TESTS_PASSED=$((TESTS_PASSED + 1))
+    else
+        log_error "VPA owner reference kind is '${owner_kind}', expected 'Deployment'"
+        TESTS_FAILED=$((TESTS_FAILED + 1))
+    fi
+
+    # Check owner reference name
+    local owner_name
+    owner_name=$(kubectl get vpa test-app-vpa -n "${TEST_NAMESPACE}" -o jsonpath='{.metadata.ownerReferences[0].name}' 2>/dev/null)
+
+    if [[ "${owner_name}" == "test-app" ]]; then
+        log_success "VPA owner reference name is 'test-app'"
+        TESTS_PASSED=$((TESTS_PASSED + 1))
+    else
+        log_error "VPA owner reference name is '${owner_name}', expected 'test-app'"
+        TESTS_FAILED=$((TESTS_FAILED + 1))
+    fi
+
+    # Check controller flag is set
+    local controller_flag
+    controller_flag=$(kubectl get vpa test-app-vpa -n "${TEST_NAMESPACE}" -o jsonpath='{.metadata.ownerReferences[0].controller}' 2>/dev/null)
+
+    if [[ "${controller_flag}" == "true" ]]; then
+        log_success "VPA owner reference has controller=true"
+        TESTS_PASSED=$((TESTS_PASSED + 1))
+    else
+        log_error "VPA owner reference controller is '${controller_flag}', expected 'true'"
+        TESTS_FAILED=$((TESTS_FAILED + 1))
+    fi
+
+    # Check blockOwnerDeletion flag is set
+    local block_deletion_flag
+    block_deletion_flag=$(kubectl get vpa test-app-vpa -n "${TEST_NAMESPACE}" -o jsonpath='{.metadata.ownerReferences[0].blockOwnerDeletion}' 2>/dev/null)
+
+    if [[ "${block_deletion_flag}" == "true" ]]; then
+        log_success "VPA owner reference has blockOwnerDeletion=true"
+        TESTS_PASSED=$((TESTS_PASSED + 1))
+    else
+        log_error "VPA owner reference blockOwnerDeletion is '${block_deletion_flag}', expected 'true'"
+        TESTS_FAILED=$((TESTS_FAILED + 1))
+    fi
+}
+
+#######################################
 # Test: VpaManager status
 #######################################
 test_vpamanager_status() {
@@ -555,6 +610,7 @@ main() {
     # Run tests
     test_vpa_creation
     test_vpa_configuration
+    test_vpa_owner_reference
     test_vpamanager_status
     test_operator_no_errors
     test_vpa_cleanup

--- a/internal/controller/vpamanager_controller.go
+++ b/internal/controller/vpamanager_controller.go
@@ -2,6 +2,8 @@ package controller
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/json"
 	"fmt"
 	"time"
 
@@ -87,11 +89,15 @@ func (r *VpaManagerReconciler) Reconcile(ctx context.Context, req reconcile.Requ
 		return reconcile.Result{}, err
 	}
 
-	// Track managed workloads
-	managedWorkloads := []autoscalingv1.WorkloadReference{}
+	// Track counts by workload type (memory-efficient)
+	counts := map[string]int{}
+	totalManaged := 0
 	watchedWorkloadsCount := 0
 
-	// For each matching namespace, process all workload types
+	// Track VPA names for orphan cleanup
+	managedVPAKeys := make(map[string]bool)
+
+	// For each matching namespace, process all workload types with streaming
 	for _, ns := range matchingNamespaces {
 		for _, wc := range r.WorkloadConfigs {
 			selector := wc.Selector(&vpaManager.Spec)
@@ -99,36 +105,30 @@ func (r *VpaManagerReconciler) Reconcile(ctx context.Context, req reconcile.Requ
 				continue
 			}
 
-			workloads, err := wc.Provider.List(ctx, r.Client, ns.Name, selector)
-			if err != nil {
-				log.Error(err, "failed to list workloads", "kind", wc.Provider.Kind(), "namespace", ns.Name)
-				continue
-			}
-
-			watchedWorkloadsCount += len(workloads)
-			for _, wl := range workloads {
+			err := wc.Provider.ForEach(ctx, r.Client, ns.Name, selector, func(wl workload.Workload) (bool, error) {
+				watchedWorkloadsCount++
 				vpaName := fmt.Sprintf("%s-vpa", wl.GetName())
 				created, err := r.ensureVPAForWorkload(ctx, vpaManager, wl.GetKind(), wl.GetName(), wl.GetNamespace(), wl.GetUID(), vpaName)
 				if err != nil {
 					log.Error(err, "failed to ensure VPA", "kind", wl.GetKind(), "name", wl.GetName(), "namespace", wl.GetNamespace())
-					continue
+					return true, nil // continue despite error
 				}
 				if created {
 					r.Metrics.RecordVPAOperation("create", vpaManager.Name)
 				}
-				managedWorkloads = append(managedWorkloads, autoscalingv1.WorkloadReference{
-					Kind:      wl.GetKind(),
-					Name:      wl.GetName(),
-					Namespace: wl.GetNamespace(),
-					UID:       string(wl.GetUID()),
-					VpaName:   vpaName,
-				})
+				counts[wl.GetKind()]++
+				totalManaged++
+				managedVPAKeys[fmt.Sprintf("%s/%s", wl.GetNamespace(), vpaName)] = true
+				return true, nil
+			})
+			if err != nil {
+				log.Error(err, "failed to iterate workloads", "kind", wc.Provider.Kind(), "namespace", ns.Name)
 			}
 		}
 	}
 
 	// Clean up orphaned VPAs
-	orphansDeleted, err := r.cleanupOrphanedVPAs(ctx, vpaManager, managedWorkloads)
+	orphansDeleted, err := r.cleanupOrphanedVPAsWithKeys(ctx, vpaManager, managedVPAKeys)
 	if err != nil {
 		log.Error(err, "failed to cleanup orphaned VPAs")
 	}
@@ -139,9 +139,13 @@ func (r *VpaManagerReconciler) Reconcile(ctx context.Context, req reconcile.Requ
 	// Update status using Patch to avoid conflicts with stale resourceVersion
 	now := metav1.Now()
 	statusUpdate := vpaManager.DeepCopy()
-	statusUpdate.Status.ManagedVPAs = len(managedWorkloads)
-	statusUpdate.Status.ManagedDeployments = managedWorkloads // backward compatibility
-	statusUpdate.Status.ManagedWorkloads = managedWorkloads
+	statusUpdate.Status.ManagedVPAs = totalManaged
+	statusUpdate.Status.DeploymentCount = counts["Deployment"]
+	statusUpdate.Status.StatefulSetCount = counts["StatefulSet"]
+	statusUpdate.Status.DaemonSetCount = counts["DaemonSet"]
+	// Clear deprecated fields to reduce status size
+	statusUpdate.Status.ManagedDeployments = nil
+	statusUpdate.Status.ManagedWorkloads = nil
 	statusUpdate.Status.LastReconcileTime = &now
 
 	if err := r.Status().Patch(ctx, statusUpdate, client.MergeFrom(vpaManager)); err != nil {
@@ -151,10 +155,10 @@ func (r *VpaManagerReconciler) Reconcile(ctx context.Context, req reconcile.Requ
 	}
 
 	// Update metrics
-	r.Metrics.UpdateManagedResources(vpaManager.Name, len(managedWorkloads), watchedWorkloadsCount)
+	r.Metrics.UpdateManagedResources(vpaManager.Name, totalManaged, watchedWorkloadsCount)
 	r.Metrics.RecordReconcile(vpaManager.Name, start, nil)
 
-	log.Info("reconciliation complete", "managedVPAs", len(managedWorkloads), "watchedWorkloads", watchedWorkloadsCount)
+	log.Info("reconciliation complete", "managedVPAs", totalManaged, "watchedWorkloads", watchedWorkloadsCount)
 	return reconcile.Result{RequeueAfter: 5 * time.Minute}, nil
 }
 
@@ -182,9 +186,18 @@ func (r *VpaManagerReconciler) getMatchingNamespaces(ctx context.Context, select
 	return namespaceList.Items, nil
 }
 
+// specHash computes a hash of the VPA spec for change detection
+func specHash(spec map[string]interface{}) string {
+	data, _ := json.Marshal(spec)
+	hash := sha256.Sum256(data)
+	return fmt.Sprintf("%x", hash[:8])
+}
+
 // ensureVPAForWorkload creates or updates a VPA for a workload (Deployment or StatefulSet)
 func (r *VpaManagerReconciler) ensureVPAForWorkload(ctx context.Context, vpaManager *autoscalingv1.VpaManager, kind, name, namespace string, uid types.UID, vpaName string) (bool, error) {
 	vpa := r.buildVPAForWorkload(vpaManager, kind, name, namespace, uid, vpaName)
+	desiredSpec := vpa.Object["spec"].(map[string]interface{})
+	desiredHash := specHash(desiredSpec)
 
 	// Check if VPA already exists
 	existing := &unstructured.Unstructured{}
@@ -193,6 +206,14 @@ func (r *VpaManagerReconciler) ensureVPAForWorkload(ctx context.Context, vpaMana
 
 	if err != nil {
 		if errors.IsNotFound(err) {
+			// Add spec hash annotation for future change detection
+			annotations := vpa.GetAnnotations()
+			if annotations == nil {
+				annotations = make(map[string]string)
+			}
+			annotations["vpa-operator.io/spec-hash"] = desiredHash
+			vpa.SetAnnotations(annotations)
+
 			// Create VPA
 			if err := r.Create(ctx, vpa); err != nil {
 				return false, err
@@ -202,8 +223,27 @@ func (r *VpaManagerReconciler) ensureVPAForWorkload(ctx context.Context, vpaMana
 		return false, err
 	}
 
-	// Update existing VPA if needed
-	existing.Object["spec"] = vpa.Object["spec"]
+	// Check if update is needed using hash comparison
+	existingAnnotations := existing.GetAnnotations()
+	existingHash := ""
+	if existingAnnotations != nil {
+		existingHash = existingAnnotations["vpa-operator.io/spec-hash"]
+	}
+
+	// Skip update if spec hasn't changed
+	if existingHash == desiredHash {
+		return false, nil
+	}
+
+	// Update existing VPA
+	existing.Object["spec"] = desiredSpec
+	annotations := existing.GetAnnotations()
+	if annotations == nil {
+		annotations = make(map[string]string)
+	}
+	annotations["vpa-operator.io/spec-hash"] = desiredHash
+	existing.SetAnnotations(annotations)
+
 	if err := r.Update(ctx, existing); err != nil {
 		return false, err
 	}
@@ -282,16 +322,9 @@ func (r *VpaManagerReconciler) buildVPAForWorkload(vpaManager *autoscalingv1.Vpa
 	return vpa
 }
 
-// cleanupOrphanedVPAs removes VPAs for workloads that no longer match
-func (r *VpaManagerReconciler) cleanupOrphanedVPAs(ctx context.Context, vpaManager *autoscalingv1.VpaManager, currentWorkloads []autoscalingv1.WorkloadReference) (int, error) {
-	// Build a set of current VPA names
-	currentVPAs := make(map[string]bool)
-	for _, wl := range currentWorkloads {
-		key := fmt.Sprintf("%s/%s", wl.Namespace, wl.VpaName)
-		currentVPAs[key] = true
-	}
-
-	// List all VPAs managed by this operator
+// cleanupOrphanedVPAsWithKeys removes VPAs for workloads that no longer match (memory-efficient version)
+func (r *VpaManagerReconciler) cleanupOrphanedVPAsWithKeys(ctx context.Context, vpaManager *autoscalingv1.VpaManager, currentVPAKeys map[string]bool) (int, error) {
+	// List all VPAs managed by this operator with pagination
 	vpaList := &unstructured.UnstructuredList{}
 	vpaList.SetGroupVersionKind(schema.GroupVersionKind{
 		Group:   "autoscaling.k8s.io",
@@ -299,21 +332,40 @@ func (r *VpaManagerReconciler) cleanupOrphanedVPAs(ctx context.Context, vpaManag
 		Kind:    "VerticalPodAutoscalerList",
 	})
 
-	if err := r.List(ctx, vpaList, client.MatchingLabels{
-		"app.kubernetes.io/managed-by": "vpa-operator",
-		"app.kubernetes.io/created-by": vpaManager.Name,
-	}); err != nil {
-		return 0, err
+	listOpts := []client.ListOption{
+		client.MatchingLabels{
+			"app.kubernetes.io/managed-by": "vpa-operator",
+			"app.kubernetes.io/created-by": vpaManager.Name,
+		},
+		client.Limit(500),
 	}
 
 	deleted := 0
-	for _, vpa := range vpaList.Items {
-		key := fmt.Sprintf("%s/%s", vpa.GetNamespace(), vpa.GetName())
-		if !currentVPAs[key] {
-			if err := r.Delete(ctx, &vpa); err != nil && !errors.IsNotFound(err) {
-				return deleted, err
+	var continueToken string
+
+	for {
+		opts := listOpts
+		if continueToken != "" {
+			opts = append(opts, client.Continue(continueToken))
+		}
+
+		if err := r.List(ctx, vpaList, opts...); err != nil {
+			return deleted, err
+		}
+
+		for _, vpa := range vpaList.Items {
+			key := fmt.Sprintf("%s/%s", vpa.GetNamespace(), vpa.GetName())
+			if !currentVPAKeys[key] {
+				if err := r.Delete(ctx, &vpa); err != nil && !errors.IsNotFound(err) {
+					return deleted, err
+				}
+				deleted++
 			}
-			deleted++
+		}
+
+		continueToken = vpaList.GetContinue()
+		if continueToken == "" {
+			break
 		}
 	}
 

--- a/internal/webhook/deployment_webhook.go
+++ b/internal/webhook/deployment_webhook.go
@@ -281,12 +281,16 @@ func (h *DeploymentWebhookHandler) buildVPA(vpaManager *autoscalingv1.VpaManager
 	})
 
 	// Set owner reference to deployment for garbage collection
+	controller := true
+	blockOwnerDeletion := true
 	vpa.SetOwnerReferences([]metav1.OwnerReference{
 		{
-			APIVersion: "apps/v1",
-			Kind:       "Deployment",
-			Name:       deployment.Name,
-			UID:        deployment.UID,
+			APIVersion:         "apps/v1",
+			Kind:               "Deployment",
+			Name:               deployment.Name,
+			UID:                deployment.UID,
+			Controller:         &controller,
+			BlockOwnerDeletion: &blockOwnerDeletion,
 		},
 	})
 

--- a/internal/workload/daemonset.go
+++ b/internal/workload/daemonset.go
@@ -24,27 +24,56 @@ type DaemonSetProvider struct{}
 func (p *DaemonSetProvider) Kind() string { return "DaemonSet" }
 
 func (p *DaemonSetProvider) List(ctx context.Context, c client.Client, namespace string, selector *metav1.LabelSelector) ([]Workload, error) {
-	list := &appsv1.DaemonSetList{}
+	var workloads []Workload
+	err := p.ForEach(ctx, c, namespace, selector, func(w Workload) (bool, error) {
+		workloads = append(workloads, w)
+		return true, nil
+	})
+	return workloads, err
+}
 
-	listOpts := []client.ListOption{client.InNamespace(namespace)}
+func (p *DaemonSetProvider) ForEach(ctx context.Context, c client.Client, namespace string, selector *metav1.LabelSelector, callback WorkloadCallback) error {
+	listOpts := []client.ListOption{
+		client.InNamespace(namespace),
+		client.Limit(PageSize),
+	}
 
 	if selector != nil {
 		labelSelector, err := metav1.LabelSelectorAsSelector(selector)
 		if err != nil {
-			return nil, err
+			return err
 		}
 		listOpts = append(listOpts, client.MatchingLabelsSelector{Selector: labelSelector})
 	}
 
-	if err := c.List(ctx, list, listOpts...); err != nil {
-		return nil, err
-	}
+	var continueToken string
+	for {
+		list := &appsv1.DaemonSetList{}
+		opts := listOpts
+		if continueToken != "" {
+			opts = append(opts, client.Continue(continueToken))
+		}
 
-	workloads := make([]Workload, len(list.Items))
-	for i := range list.Items {
-		workloads[i] = &DaemonSetWorkload{&list.Items[i]}
+		if err := c.List(ctx, list, opts...); err != nil {
+			return err
+		}
+
+		for i := range list.Items {
+			continueIteration, err := callback(&DaemonSetWorkload{&list.Items[i]})
+			if err != nil {
+				return err
+			}
+			if !continueIteration {
+				return nil
+			}
+		}
+
+		continueToken = list.GetContinue()
+		if continueToken == "" {
+			break
+		}
 	}
-	return workloads, nil
+	return nil
 }
 
 func (p *DaemonSetProvider) NewObject() client.Object {

--- a/internal/workload/deployment.go
+++ b/internal/workload/deployment.go
@@ -24,27 +24,56 @@ type DeploymentProvider struct{}
 func (p *DeploymentProvider) Kind() string { return "Deployment" }
 
 func (p *DeploymentProvider) List(ctx context.Context, c client.Client, namespace string, selector *metav1.LabelSelector) ([]Workload, error) {
-	list := &appsv1.DeploymentList{}
+	var workloads []Workload
+	err := p.ForEach(ctx, c, namespace, selector, func(w Workload) (bool, error) {
+		workloads = append(workloads, w)
+		return true, nil
+	})
+	return workloads, err
+}
 
-	listOpts := []client.ListOption{client.InNamespace(namespace)}
+func (p *DeploymentProvider) ForEach(ctx context.Context, c client.Client, namespace string, selector *metav1.LabelSelector, callback WorkloadCallback) error {
+	listOpts := []client.ListOption{
+		client.InNamespace(namespace),
+		client.Limit(PageSize),
+	}
 
 	if selector != nil {
 		labelSelector, err := metav1.LabelSelectorAsSelector(selector)
 		if err != nil {
-			return nil, err
+			return err
 		}
 		listOpts = append(listOpts, client.MatchingLabelsSelector{Selector: labelSelector})
 	}
 
-	if err := c.List(ctx, list, listOpts...); err != nil {
-		return nil, err
-	}
+	var continueToken string
+	for {
+		list := &appsv1.DeploymentList{}
+		opts := listOpts
+		if continueToken != "" {
+			opts = append(opts, client.Continue(continueToken))
+		}
 
-	workloads := make([]Workload, len(list.Items))
-	for i := range list.Items {
-		workloads[i] = &DeploymentWorkload{&list.Items[i]}
+		if err := c.List(ctx, list, opts...); err != nil {
+			return err
+		}
+
+		for i := range list.Items {
+			continueIteration, err := callback(&DeploymentWorkload{&list.Items[i]})
+			if err != nil {
+				return err
+			}
+			if !continueIteration {
+				return nil
+			}
+		}
+
+		continueToken = list.GetContinue()
+		if continueToken == "" {
+			break
+		}
 	}
-	return workloads, nil
+	return nil
 }
 
 func (p *DeploymentProvider) NewObject() client.Object {

--- a/internal/workload/workload.go
+++ b/internal/workload/workload.go
@@ -8,6 +8,9 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
+// PageSize is the default number of items to fetch per page
+const PageSize = 500
+
 // Workload abstracts Deployment, StatefulSet, DaemonSet for VPA management
 type Workload interface {
 	GetName() string
@@ -18,13 +21,22 @@ type Workload interface {
 	GetAPIVersion() string
 }
 
+// WorkloadCallback is called for each workload during iteration
+// Return false to stop iteration, or an error to abort with error
+type WorkloadCallback func(Workload) (continueIteration bool, err error)
+
 // Provider lists and matches workloads of a specific type
 type Provider interface {
 	// Kind returns the workload kind (e.g., "Deployment", "StatefulSet", "DaemonSet")
 	Kind() string
 
 	// List returns all workloads in a namespace matching the selector
+	// Deprecated: Use ForEach for better memory efficiency with large datasets
 	List(ctx context.Context, c client.Client, namespace string, selector *metav1.LabelSelector) ([]Workload, error)
+
+	// ForEach iterates over workloads with pagination, calling the callback for each
+	// This is more memory-efficient than List for large datasets
+	ForEach(ctx context.Context, c client.Client, namespace string, selector *metav1.LabelSelector, callback WorkloadCallback) error
 
 	// NewObject returns a new empty object for controller watches
 	NewObject() client.Object


### PR DESCRIPTION
- Add commonLabels, commonAnnotations, podLabels, and podAnnotations support to Helm chart templates
- Include ArgoCD deployment example with values for recommendation-only mode
- Set controller and blockOwnerDeletion flags on VPA owner references for proper garbage collection
- Add validation test for VPA owner reference configuration
- Use status patch instead of update in VpaManager controller to avoid conflicts